### PR TITLE
Fetch languages server-side to avoid client waterfalls

### DIFF
--- a/src/app/demo/page.tsx
+++ b/src/app/demo/page.tsx
@@ -1,12 +1,41 @@
 import type { Metadata } from "next"
 import { QuranReader } from "@/components/quran-reader"
+import { LANGUAGE_MAP } from "@/lib/quran-utils"
+
+const BASE_URL = "https://alquran-api.pages.dev"
 
 export const metadata: Metadata = {
   title: "Demo App - Al-Quran API",
   description: "Interactive demo application showcasing the Al-Quran API capabilities",
 }
 
-export default function DemoPage() {
+async function getInitialData() {
+  try {
+    const [langRes, surahRes] = await Promise.all([
+      fetch(`${BASE_URL}/api/quran/languages`),
+      fetch(`${BASE_URL}/api/quran?lang=en`),
+    ])
+
+    const [langData, surahData]: [any, any] = await Promise.all([
+      langRes.ok ? langRes.json() : null,
+      surahRes.ok ? surahRes.json() : null,
+    ])
+
+    return {
+      languages: langData?.languages || Object.values(LANGUAGE_MAP),
+      surahs: surahData?.surahs || [],
+    }
+  } catch {
+    return {
+      languages: Object.values(LANGUAGE_MAP),
+      surahs: [],
+    }
+  }
+}
+
+export default async function DemoPage() {
+  const { languages, surahs } = await getInitialData()
+
   return (
     <div className="container py-10">
       <div className="max-w-3xl mx-auto">
@@ -15,7 +44,11 @@ export default function DemoPage() {
           <p className="text-muted-foreground">An interactive demo application powered by the Al-Quran API</p>
         </div>
 
-        <QuranReader baseUrl="https://alquran-api.pages.dev" />
+        <QuranReader
+          baseUrl={BASE_URL}
+          initialLanguages={languages}
+          initialSurahs={surahs}
+        />
       </div>
     </div>
   )

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,6 +21,7 @@ import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }
 import { ApiTester } from "@/components/api-tester"
 import { LanguageShowcase } from "@/components/language-showcase"
 import { Badge } from "@/components/ui/badge"
+import { LANGUAGE_MAP } from "@/lib/quran-utils"
 
 export const metadata: Metadata = {
   title: "Al-Quran API - Multilingual Quran API with Translations & Search",
@@ -29,6 +30,7 @@ export const metadata: Metadata = {
 }
 
 export default function HomePage() {
+  const languages = Object.values(LANGUAGE_MAP)
   return (
     <>
       {/* Hero Section */}
@@ -257,7 +259,7 @@ export default function HomePage() {
             </p>
           </div>
           <div className="mx-auto max-w-5xl py-12">
-            <LanguageShowcase />
+            <LanguageShowcase languages={languages} />
           </div>
         </div>
       </section>

--- a/src/components/language-showcase.tsx
+++ b/src/components/language-showcase.tsx
@@ -1,70 +1,14 @@
 "use client"
 
-import { useState, useEffect, Suspense } from "react"
 import { motion } from "framer-motion"
-import { Skeleton } from "@/components/ui/skeleton"
 import { Badge } from "@/components/ui/badge"
 import type { Language } from "@/lib/quran-utils"
 
-interface ApiResponse {
-  languages?: Language[]
-  error?: string
+interface LanguageShowcaseProps {
+  languages: Language[]
 }
 
-function LanguageShowcaseInner() {
-  const [languages, setLanguages] = useState<Language[]>([])
-  const [isLoading, setIsLoading] = useState<boolean>(true)
-  const [error, setError] = useState<string | null>(null)
-
-  useEffect(() => {
-    const fetchLanguages = async () => {
-      try {
-        setIsLoading(true)
-        setError(null)
-
-        const response = await fetch("https://alquran-api.pages.dev/api/quran/languages")
-
-        if (!response.ok) {
-          throw new Error(`Failed to fetch languages: ${response.status} ${response.statusText}`)
-        }
-
-        const data = (await response.json()) as ApiResponse
-
-        if (data.error) {
-          throw new Error(data.error)
-        }
-
-        setLanguages(data.languages || [])
-      } catch (error) {
-        console.error("Failed to fetch languages:", error)
-        setError(error instanceof Error ? error.message : "Failed to fetch languages")
-        // Set default languages as fallback
-        setLanguages([
-          { code: "ar", name: "Arabic", nativeName: "العربية", direction: "rtl" },
-          { code: "bn", name: "Bengali", nativeName: "বাংলা", direction: "ltr" },
-          { code: "en", name: "English", nativeName: "English", direction: "ltr" },
-          { code: "fr", name: "French", nativeName: "Français", direction: "ltr" },
-          { code: "id", name: "Indonesian", nativeName: "Bahasa Indonesia", direction: "ltr" },
-          { code: "ur", name: "Urdu", nativeName: "اردو", direction: "rtl" },
-        ])
-      } finally {
-        setIsLoading(false)
-      }
-    }
-
-    fetchLanguages()
-  }, [])
-
-  if (isLoading) {
-    return (
-      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-        {Array.from({ length: 8 }).map((_, i) => (
-          <Skeleton key={i} className="h-24 rounded-lg" />
-        ))}
-      </div>
-    )
-  }
-
+export function LanguageShowcase({ languages }: LanguageShowcaseProps) {
   return (
     <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
       {languages.map((language, index) => (
@@ -83,22 +27,6 @@ function LanguageShowcaseInner() {
         </motion.div>
       ))}
     </div>
-  )
-}
-
-export function LanguageShowcase() {
-  return (
-    <Suspense
-      fallback={
-        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-          {Array.from({ length: 8 }).map((_, i) => (
-            <Skeleton key={i} className="h-24 rounded-lg" />
-          ))}
-        </div>
-      }
-    >
-      <LanguageShowcaseInner />
-    </Suspense>
   )
 }
 

--- a/src/components/quran-reader.tsx
+++ b/src/components/quran-reader.tsx
@@ -47,16 +47,18 @@ interface ApiResponse {
 
 interface QuranReaderProps {
   baseUrl: string
+  initialLanguages?: Language[]
+  initialSurahs?: Surah[]
 }
 
-function QuranReaderInner({ baseUrl }: QuranReaderProps) {
-  const [languages, setLanguages] = useState<Language[]>([])
+function QuranReaderInner({ baseUrl, initialLanguages, initialSurahs }: QuranReaderProps) {
+  const [languages, setLanguages] = useState<Language[]>(initialLanguages || [])
   const [selectedLanguage, setSelectedLanguage] = useState<string>("en")
-  const [surahs, setSurahs] = useState<Surah[]>([])
+  const [surahs, setSurahs] = useState<Surah[]>(initialSurahs || [])
   const [selectedSurah, setSelectedSurah] = useState<number>(1)
   const [verses, setVerses] = useState<Verse[]>([])
-  const [isLoadingLanguages, setIsLoadingLanguages] = useState<boolean>(true)
-  const [isLoadingSurahs, setIsLoadingSurahs] = useState<boolean>(true)
+  const [isLoadingLanguages, setIsLoadingLanguages] = useState<boolean>(!initialLanguages)
+  const [isLoadingSurahs, setIsLoadingSurahs] = useState<boolean>(!initialSurahs)
   const [isLoadingVerses, setIsLoadingVerses] = useState<boolean>(true)
   const [searchQuery, setSearchQuery] = useState<string>("")
   const [isSearching, setIsSearching] = useState<boolean>(false)
@@ -70,8 +72,10 @@ function QuranReaderInner({ baseUrl }: QuranReaderProps) {
 
   const audioRef = useRef<HTMLAudioElement | null>(null)
 
-  // Fetch languages
+  // Fetch languages (skip if provided via props)
   useEffect(() => {
+    if (initialLanguages && initialLanguages.length > 0) return
+
     const fetchLanguages = async () => {
       try {
         setIsLoadingLanguages(true)
@@ -117,12 +121,13 @@ function QuranReaderInner({ baseUrl }: QuranReaderProps) {
     }
 
     fetchLanguages()
-  }, [baseUrl])
+  }, [baseUrl, initialLanguages])
 
-  // Fetch surahs when language changes
+  // Fetch surahs when language changes (skip initial fetch if provided via props)
   useEffect(() => {
     const fetchSurahs = async () => {
       if (!selectedLanguage) return
+      if (initialSurahs && initialSurahs.length > 0 && selectedLanguage === "en") return
 
       try {
         setIsLoadingSurahs(true)
@@ -575,7 +580,11 @@ function QuranReaderInner({ baseUrl }: QuranReaderProps) {
 export function QuranReader(props: QuranReaderProps) {
   return (
     <Suspense fallback={<Skeleton className="h-[800px] w-full" />}>
-      <QuranReaderInner {...props} />
+      <QuranReaderInner
+        baseUrl={props.baseUrl}
+        initialLanguages={props.initialLanguages}
+        initialSurahs={props.initialSurahs}
+      />
     </Suspense>
   )
 }


### PR DESCRIPTION
- Refactor LanguageShowcase to accept languages as props instead of fetching client-side
- Pass LANGUAGE_MAP from server component on homepage (no network request needed)
- Add initialLanguages/initialSurahs props to QuranReader to skip redundant client fetches
- Fetch languages and surahs server-side in demo page with Promise.all()