### PR TITLE
Improve rendering and JS performance for verse lists

### DIFF
--- a/src/app/api/quran/surah/[id]/route.ts
+++ b/src/app/api/quran/surah/[id]/route.ts
@@ -28,8 +28,8 @@ export async function GET(request: Request, { params }: { params: { id: string }
       return NextResponse.json({ error: "Failed to load Quran data" }, { status: 500 })
     }
 
-    // Find the requested surah
-    const surah = quranData.find((s: any) => s.id === surahId)
+    // Get the requested surah by index (IDs are sequential 1-114)
+    const surah = quranData[surahId - 1]
 
     if (!surah) {
       return NextResponse.json({ error: "Surah not found" }, { status: 404 })

--- a/src/app/api/quran/surah/[id]/verse/[verseId]/route.ts
+++ b/src/app/api/quran/surah/[id]/verse/[verseId]/route.ts
@@ -33,8 +33,8 @@ export async function GET(request: Request, { params }: { params: { id: string; 
       return NextResponse.json({ error: "Failed to load Quran data" }, { status: 500 })
     }
 
-    // Find the requested surah
-    const surah = quranData.find((s: any) => s.id === surahId)
+    // Get the requested surah by index (IDs are sequential 1-114)
+    const surah = quranData[surahId - 1]
 
     if (!surah) {
       return NextResponse.json({ error: "Surah not found" }, { status: 404 })

--- a/src/components/quran-reader.tsx
+++ b/src/components/quran-reader.tsx
@@ -464,7 +464,6 @@ function QuranReaderInner({ baseUrl }: QuranReaderProps) {
                         animate={{ opacity: 1 }}
                         exit={{ opacity: 0 }}
                         className="space-y-2"
-                        style={{ contentVisibility: "auto", containIntrinsicSize: "0 80px" }}
                       >
                         <div className="flex items-center justify-between">
                           <Badge variant="outline" className="bg-emerald-50 dark:bg-emerald-900/20">

--- a/src/components/quran-reader.tsx
+++ b/src/components/quran-reader.tsx
@@ -464,6 +464,7 @@ function QuranReaderInner({ baseUrl }: QuranReaderProps) {
                         animate={{ opacity: 1 }}
                         exit={{ opacity: 0 }}
                         className="space-y-2"
+                        style={{ contentVisibility: "auto", containIntrinsicSize: "0 80px" }}
                       >
                         <div className="flex items-center justify-between">
                           <Badge variant="outline" className="bg-emerald-50 dark:bg-emerald-900/20">


### PR DESCRIPTION
- Add content-visibility: auto to verse containers to skip rendering off-screen verses (surahs can have 200+ verses)
- Use direct array index instead of .find() for surah lookup in API routes since surah IDs are sequential 1-114